### PR TITLE
[CI] pyOpenMS wheels: exclude TOPP tools at configure time

### DIFF
--- a/.github/workflows/pyopenms-wheels-cibuildwheel.yml
+++ b/.github/workflows/pyopenms-wheels-cibuildwheel.yml
@@ -134,6 +134,8 @@ jobs:
                 -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
                 -DPYOPENMS=OFF \
                 -DWITH_GUI=OFF \
+                -DBUILD_TOPP_TOOLS=OFF \
+                -DINSTALL_OPENMS_EXAMPLES=OFF \
                 -DWITH_THERMO_RAW=OFF \
                 -DENABLE_TUTORIALS=OFF \
                 -DENABLE_DOCS=OFF
@@ -216,6 +218,8 @@ jobs:
                 -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
                 -DPYOPENMS=OFF \
                 -DWITH_GUI=OFF \
+                -DBUILD_TOPP_TOOLS=OFF \
+                -DINSTALL_OPENMS_EXAMPLES=OFF \
                 -DWITH_THERMO_RAW=OFF \
                 -DENABLE_TUTORIALS=OFF \
                 -DENABLE_DOCS=OFF
@@ -294,6 +298,8 @@ jobs:
             -DARROW_USE_STATIC=OFF \
             -DPYOPENMS=OFF \
             -DWITH_GUI=OFF \
+            -DBUILD_TOPP_TOOLS=OFF \
+            -DINSTALL_OPENMS_EXAMPLES=OFF \
             -DENABLE_TUTORIALS=OFF \
             -DENABLE_DOCS=OFF \
             -DMT_ENABLE_OPENMP=ON
@@ -402,6 +408,8 @@ jobs:
             -DOPENMS_CONTRIB_LIBS="$GITHUB_WORKSPACE/contrib" \
             -DPYOPENMS=OFF \
             -DWITH_GUI=OFF \
+            -DBUILD_TOPP_TOOLS=OFF \
+            -DINSTALL_OPENMS_EXAMPLES=OFF \
             -DWITH_THERMO_RAW=OFF \
             -DENABLE_TUTORIALS=OFF \
             -DENABLE_DOCS=OFF


### PR DESCRIPTION
## Summary

Stacked on top of #9752 (OpenMS/OpenMS). Uses the new core-only build
options in the pyOpenMS wheel workflow: adds
`-DBUILD_TOPP_TOOLS=OFF -DINSTALL_OPENMS_EXAMPLES=OFF` to all four
platform configure blocks (Linux x64/arm64, macOS arm64, Windows x64).

## Why

The wheel jobs already avoid compiling TOPP by building only the named
library targets (`ninja OpenMS OpenSwathAlgo` / `cmake --build . --target
OpenMS OpenSwathAlgo`) and installing a hand-picked subset of components.
Passing the new flags moves that intent to configure time:

- the `src/topp` subtree is no longer configured (slightly faster configure);
- the build stays correct even if the target list is ever changed to a
  plain `ninja` / `all` build (TOPP simply won't exist to build);
- documents that the wheel is a core-lib-only consumer.

No functional change to the produced wheels — TOPP was never in them.

## Scope

Minimal by design: only the four configure invocations change. The
`ninja OpenMS OpenSwathAlgo` target selection and the à-la-carte
`cmake --install --component ...` steps are left as-is. A follow-up could
collapse those into a single unqualified `cmake --install . --strip`
(per #9752's validated core-only install graph), but that is intentionally
out of scope here.

## Dependency / merge order

Requires #9752 (introduces `BUILD_TOPP_TOOLS` and `INSTALL_OPENMS_EXAMPLES`).
Base is set to the `agent/core-only-openms-build` branch; retarget to
`develop` once #9752 has merged. On plain `develop` these flags would be
unknown vars (silently ignored by CMake), so this must land after #9752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)